### PR TITLE
Head back to the root dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ cache:
   - node_modules
   - vendor
 
+install:
+- cd wp/wp-content/themes/bethandnick
+- composer install
+- cd ../../../../
+
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_7dcc3917ca87_key -iv $encrypted_7dcc3917ca87_iv
   -in .travis/deploy_rsa.enc -out .travis/deploy_rsa -d
@@ -26,10 +31,6 @@ before_deploy:
 - chmod 600 .travis/deploy_rsa
 - ssh-add .travis/deploy_rsa
 - nvm install
-
-install:
-- cd wp/wp-content/themes/bethandnick
-- composer install
 
 script:
 - 


### PR DESCRIPTION
Update Travis scripts so that when we go into the WP theme to do the composer install, we then come back out to the root to do all the other things.